### PR TITLE
Fix module import path and generated alias

### DIFF
--- a/src/malli_ts/core.cljc
+++ b/src/malli_ts/core.cljc
@@ -46,17 +46,17 @@
    (-parse-ast-node node {})))
 
 (defmethod -parse-ast-node :$ref
-  [{:keys [$ref] :as node} {:keys [deref-types
+  [{:keys [$ref] :as node} {:keys [deref-type
                                    schema-id->type-options
                                    files-import-alias*
                                    file-imports*
                                    file]
                             :as options}]
-  (if (or (get deref-types $ref) (not (get schema-id->type-options $ref)))
+  (if (or (= deref-type $ref) (not (get schema-id->type-options $ref)))
     (-parse-ast-node
      (or (get-in node [:definitions $ref])
          (->ast (:schema node)))
-     options)
+     (dissoc options :deref-type))
     (let [ref-file (get-in schema-id->type-options [$ref :file])
           import-alias (or (get @files-import-alias* ref-file)
                            (get
@@ -69,8 +69,7 @@
                                  $)
                                (string/join "_" $)))
                             ref-file))
-          ref-type-name (or (get-in schema-id->type-options [$ref :t-name])
-                            (get (m/properties (m/deref $ref options)) ::t-name))
+          ref-type-name (get-in schema-id->type-options [$ref :t-name])
           same-file? (= file ref-file)]
       (when-not same-file?
         (swap! file-imports* update file set/union #{ref-file}))
@@ -137,22 +136,31 @@
    {}))
 
 (defmethod -parse-ast-node :external-type [{:keys [schema]}
-                                           {:keys [file
+                                           {:keys [deref-type
+                                                   file
                                                    files-import-alias*
-                                                   file-imports*]}]
+                                                   file-imports*
+                                                   schema-id->type-options]}]
   (let [{:keys [::t-name ::t-path ::t-alias]} (m/properties schema)
-        is-imported-already (if t-path (@file-imports* t-path) nil)
-        canonical-alias (if t-path (get @files-import-alias* t-path) nil)
-        import-alias (if (or canonical-alias (not t-path))
-                       canonical-alias
-                       (if t-alias
-                         t-alias
-                         (csk/->camelCase (string/join "-" (drop-last (string/split t-path #"/"))))))]
-    (when (and t-path (not is-imported-already))
+        {:keys [t-name t-path t-alias]
+         :or {t-name t-name t-path t-path t-alias t-alias}} (get schema-id->type-options deref-type)
+        t-path-str (or (:absolute t-path) t-path)
+        is-imported-already (if t-path-str (@file-imports* t-path) nil)
+        canonical-alias (if t-path-str (get @files-import-alias* t-path-str) nil)
+        import-alias (or canonical-alias
+                         (cond
+                           t-alias t-alias
+                           t-path-str (as-> t-path-str $
+                                        (string/replace $ #"\.d\.ts" "")
+                                        (string/split $ #"[./]")
+                                        (string/join "-" $)
+                                        (csk/->snake_case $))
+                           :else nil))]
+    (when (and t-path-str (not is-imported-already))
       (swap! file-imports* update file set/union #{t-path}))
-    (when (and t-path (not canonical-alias))
-      (swap! files-import-alias* assoc t-path import-alias))
-    (str (if t-path (str import-alias ".") nil) t-name)))
+    (when (and import-alias (not canonical-alias))
+      (swap! files-import-alias* assoc t-path-str import-alias))
+    (str (if import-alias (str import-alias ".") nil) t-name)))
 
 (defn- letter-args
   ([letter-arg]
@@ -265,7 +273,11 @@
                               (filter (fn [[k _]] (= (namespace k) "malli-ts.core")))
                               (map (fn [[k v]] [(-> k name keyword) v])))
                              (m/properties (m/deref schema-id options)))
-                       type-options (merge schema-type-options type-options)]
+                       type-options (merge  type-options
+                                            schema-type-options)
+                       type-options (if-not (:t-name type-options)
+                                      (assoc type-options :t-name (csk/->snake_case (name schema-id)))
+                                      type-options)]
                    (assoc m schema-id (assoc type-options :file file))))
                {} schema-type-vectors)))
    {} file->schema-type-vectors))
@@ -284,15 +296,17 @@
    (fn [m [file schema-type-vectors]]
      (reduce
       (fn [m schema-type-vector]
-        (let [[schema-id type-options] (if (seq? schema-type-vector)
+        (let [[schema-id type-options] (if (seqable? schema-type-vector)
                                          schema-type-vector
                                          [schema-type-vector])
               {:keys [jsdoc] :as type-options} (merge type-options (get m schema-id))
-              literal (-parse-ast-node (->ast schema-id options)
-                                       (merge options
-                                              {:deref-types {schema-id true}
-                                               :file file
-                                               :t-options type-options}))
+              literal
+              (-parse-ast-node
+               (->ast schema-id options)
+               (merge options
+                      {:deref-type schema-id 
+                       :file file
+                       :t-options type-options}))
               jsdoc-literal
               (->> (concat jsdoc-default jsdoc)
                    (map #(provide-jsdoc % schema-id type-options options))
@@ -316,20 +330,23 @@
   [file->schema-type-vectors
    {:keys [schema-id->type-options export-default files-import-alias* file-imports*]}]
   (reduce
-   (fn [[m-import m-type] [file scheva-type-vs]]
+   (fn [[m-import m-type] [file scheva-type-vectors]]
      [(assoc
        m-import file
        (map
         (fn [import-file]
           (import-literal
            (import-path-relative file import-file)
-           (get @files-import-alias* import-file)))
+           (get @files-import-alias* (or (:absolute import-file) import-file))))
         (get @file-imports* file)))
       (assoc
        m-type file
        (map
-        (fn [[schema-id _]]
-          (let [{:keys [t-name literal jsdoc-literal export] :as t-options}
+        (fn [schema-type-vector]
+          (let [[schema-id _] (if (seqable? schema-type-vector)
+                                schema-type-vector
+                                [schema-type-vector])
+                {:keys [t-name literal jsdoc-literal export] :as t-options}
                 (get schema-id->type-options schema-id)
                 t-name (or t-name
                            (munge (name schema-id)))]
@@ -337,7 +354,7 @@
              t-name literal jsdoc-literal
              (merge t-options
                     {:export (if (some? export) export export-default)}))))
-        scheva-type-vs))])
+        scheva-type-vectors))])
    [{} {}] file->schema-type-vectors))
 
 (m/=> parse-files
@@ -428,7 +445,10 @@
   ([type-name type-path type-import-alias]
    [any? {::external-type true
           ::t-name type-name
-          ::t-path type-path
+          ::t-path (cond
+                     (nil? type-path) nil
+                     (map? type-path) type-path
+                     :else {:absolute type-path})
           ::t-alias type-import-alias}])
   ([type-name type-path]
    (external-type type-name type-path nil))

--- a/src/malli_ts/core_schema.cljc
+++ b/src/malli_ts/core_schema.cljc
@@ -1,18 +1,5 @@
 (ns malli-ts.core-schema)
 
-(comment
-  (require '[malli.provider :as mp]))
-
-(comment
-  (prn (mp/provide [{"malli-ts.ts.d.ts" [[:k {:declare true}]
-                                         [:sym {:declare true}]
-                                         [:toClj {:declare true}]
-                                         [:validate {:declare true}]
-                                         [:answerUltimateQuestion {:declare true}]
-                                         [:now {:t-name "now" :declare true}]
-                                         [:toSha256 {:t-name "toSha256" :declare true}]]
-                     "random/dir/universe.d.ts" [[:random.dir.universe/answer-to-everything {:t-name "answerToEverything"}]]}])))
-
 (def schema-type-options
   [:map
    [:declare {:optional true} boolean?]
@@ -26,9 +13,11 @@
   [:map-of
    string?
    [:vector
-    [:catn
-     [:schema-id keyword?]
-     [:schema-type-options schema-type-options]]]])
+    [:or
+     [:catn
+      [:schema-id keyword?]
+      [:schema-type-options schema-type-options]]
+     keyword?]]])
 
 (def parse-files-options
   [:map

--- a/test/malli_ts/core_test.cljc
+++ b/test/malli_ts/core_test.cljc
@@ -50,14 +50,17 @@
                        [::answerUltimateQuestion {:declare true}]
                        [::now {:t-name "now" :declare true}]
                        [::toSha256 {:t-name "toSha256" :declare true}]]
-   "random/dir/universe.d.ts" [[:random.dir.universe/answer-to-everything {:t-name "answerToEverything"}]]})
+   "random/dir/universe.d.ts" [[:random.dir.universe/answer-to-everything {:t-name "answerToEverything"}]]
+   "random/util/string" [:random.util.string/get-default-string-decoder]})
 
-(def parse-ns-schemas-data '#{malli-ts.core-test random.dir.universe})
+(def parse-ns-schemas-data
+  '#{malli-ts.core-test random.dir.universe random.util.string})
 
 (def parse-files-options
   {:export-default true
    :jsdoc-default [::mts/schema]
    :use-default-schemas true
+   :file-import-alias {'random.util.string "utilString"}
    :registry
    {::k [:=> [:catn [:s string?]] any?]
     ::sym [:=> [:catn [:s string?]] any?]
@@ -65,6 +68,10 @@
     ::validate [:=> [:catn [:schema any?] [:val any?]] any?]
     
     :random.dir.universe/answer-to-everything [:enum 42]
+
+    :random.util.string/get-default-string-decoder
+    [:=> :catn (mts/external-type "StringDecoder" "string_decoder")]
+    
     ::answerUltimateQuestion [:=> :cat :random.dir.universe/answer-to-everything]
 
     :global/date (mts/external-type "Date")

--- a/test/malli_ts/core_test.cljc
+++ b/test/malli_ts/core_test.cljc
@@ -4,7 +4,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing]])
    [malli-ts.ast :refer [->ast]]
    [malli-ts.core :refer [->type-declaration-str -jsdoc-literal parse-ast-node
-                          parse-files] :as mts]
+                          parse-files parse-ns-schemas] :as mts]
    [malli.instrument :as mi]
    [malli.dev.pretty :as malli-dev-pretty]))
 
@@ -43,40 +43,50 @@
            declaration-str))))
 
 (def parse-files-data
-  {"malli-ts.ts.d.ts" [[:k {:declare true}]
-                       [:sym {:declare true}]
-                       [:toClj {:declare true}]
-                       [:validate {:declare true}]
-                       [:answerUltimateQuestion {:declare true}]
-                       [:now {:t-name "now" :declare true}]
-                       [:toSha256 {:t-name "toSha256" :declare true}]]
+  {"malli_ts.ts.d.ts" [[::k {:declare true}]
+                       [::sym {:declare true}]
+                       [::toClj {:declare true}]
+                       [::validate {:declare true}]
+                       [::answerUltimateQuestion {:declare true}]
+                       [::now {:t-name "now" :declare true}]
+                       [::toSha256 {:t-name "toSha256" :declare true}]]
    "random/dir/universe.d.ts" [[:random.dir.universe/answer-to-everything {:t-name "answerToEverything"}]]})
+
+(def parse-ns-schemas-data '#{malli-ts.core-test random.dir.universe})
 
 (def parse-files-options
   {:export-default true
    :jsdoc-default [::mts/schema]
    :use-default-schemas true
    :registry
-   {:k [:=> [:catn [:s string?]] any?]
-    :sym [:=> [:catn [:s string?]] any?]
-    :toClj [:=> [:catn [:o any?]] any?]
-    :validate [:=> [:catn [:schema any?] [:val any?]] any?]
+   {::k [:=> [:catn [:s string?]] any?]
+    ::sym [:=> [:catn [:s string?]] any?]
+    ::toClj [:=> [:catn [:o any?]] any?]
+    ::validate [:=> [:catn [:schema any?] [:val any?]] any?]
     
     :random.dir.universe/answer-to-everything [:enum 42]
-    :answerUltimateQuestion [:=> :cat :random.dir.universe/answer-to-everything]
+    ::answerUltimateQuestion [:=> :cat :random.dir.universe/answer-to-everything]
 
     :global/date (mts/external-type "Date")
-    :now [:=> [:cat] :global/date]
+    ::now [:=> [:cat] :global/date]
 
     :crypto/hash (mts/external-type "Hash" {:absolute "crypto"} "crypto")
-    :toSha256 [:=> [:catn [:s string?]] :crypto/hash]}})
+    ::toSha256 [:=> [:catn [:s string?]] :crypto/hash]}})
 
 (comment
-  (prn (parse-files parse-files-data parse-files-options)))
+  (prn (parse-files parse-files-data parse-files-options))
+  (prn (parse-ns-schemas parse-ns-schemas-data parse-files-options)))
 
 (deftest parsing
-  (is (= {"malli-ts.ts.d.ts" "import * as crypto from 'crypto';\nimport * as randomDir from '../random/dir/universe.d.ts';\n\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var k: (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var sym: (s:string) => any;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport var toClj: (o:any) => any;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport var validate: (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport var answerUltimateQuestion: () => randomDir.answerToEverything;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport var now: () => Date;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport var toSha256: (s:string) => crypto.Hash;", "random/dir/universe.d.ts" "/**\n * @schema [:enum 42]\n */\nexport type answerToEverything = (42);"}
-         (parse-files parse-files-data parse-files-options))))
+  (is (= {"malli_ts.ts.d.ts" "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random/dir/universe.d.ts';\n\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var k: (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var sym: (s:string) => any;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport var toClj: (o:any) => any;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport var validate: (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport var answerUltimateQuestion: () => random_dir_universe.answerToEverything;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport var now: () => Date;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport var toSha256: (s:string) => crypto.Hash;",
+          "random/dir/universe.d.ts" "/**\n * @schema [:enum 42]\n */\nexport type answerToEverything = (42);"}
+         (parse-files parse-files-data parse-files-options)))
+
+  (is (= {"random.dir.universe.d.ts"
+          "/**\n * @schema [:enum 42]\n */\nexport type answer_to_everything = (42);",
+          "malli_ts.core_test.d.ts"
+          "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random.dir.universe';\n\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport type answerUltimateQuestion = () => random_dir_universe.;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport type validate = (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport type now = () => Date;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport type toClj = (o:any) => any;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport type toSha256 = (s:string) => crypto.Hash;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport type sym = (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport type k = (s:string) => any;"}
+         (parse-ns-schemas parse-ns-schemas-data parse-files-options))))
 
 (comment
   (testing "ast parsing"


### PR DESCRIPTION
Because alias is based on fully-qualified namespace, I opted to replace `.` with `_` instead of camelCase.

This PR also makes the `:files-import-alias` option more ergonomic by normalizing to strings;
