### PR TITLE
`:external-type` option now takes the TS type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,4 @@ A library for generating TS type definitions from malli schemas
 
 ### Can I get an example?
 
-Sure! Take a look at [`malli-ts.ts`](https://github.com/flowyourmoney/malli-ts/blob/master/src/malli_ts/ts.cljs) and its corresponding `shadow` build [`:malli-ts.ts_gen-types`](https://github.com/flowyourmoney/malli-ts/blob/master/shadow-cljs.edn)
-
-### I would like to know why (mt/external-type … has 2 "crypto" argument
-
-```clojure
-(defn external-type
-  ([type-name type-path type-import-alias]
-   [any? {::external-type {:t-name type-name
-                           :t-path type-path
-                           :t-alias type-import-alias}}])
-  ([type-name type-path]
-   (external-type type-name type-path nil))
-  ([type-name]
-   (external-type type-name nil nil)))
-
-(external-type "Hash" "crypto" "crypto")
-```
-
-One of them is the type path such as require('type-path') corresponds to the type's module, and then that we can refer to it as import * as type_import_alias from 'type-path' . In this specific example, both were "crypto" coincidently. 
+We're working on providing a comprehensive guide + documentation, but as of today, your best chance is reading the [`malli-ts.core-test`](./test/malli_ts/core_test.cljc).

--- a/src/malli_ts/ast.cljc
+++ b/src/malli_ts/ast.cljc
@@ -48,7 +48,7 @@
 (defmethod parse-schema-node 'uuid? [_ _ _ _] {:type :string})
 (defmethod parse-schema-node 'uri? [_ _ _ _] {:type :string})
 (defmethod parse-schema-node 'decimal? [_ _ _ _] {:type :number})
-(defmethod parse-schema-node 'inst? [_ _ _ _] {:type :string})
+(defmethod parse-schema-node 'inst? [_ _ _ _] {:type :date})
 (defmethod parse-schema-node 'seqable? [_ _ _ _] {:type :array})
 (defmethod parse-schema-node 'indexed? [_ _ _ _] {:type :array})
 (defmethod parse-schema-node 'map? [_ _ _ _] {:type :object})

--- a/src/malli_ts/core.cljc
+++ b/src/malli_ts/core.cljc
@@ -78,6 +78,7 @@
 (defmethod -parse-ast-node [:type :number] [_ _] "number")
 (defmethod -parse-ast-node [:type :string] [_ _] "string")
 (defmethod -parse-ast-node [:type :boolean] [_ _] "boolean")
+(defmethod -parse-ast-node [:type :date] [_ _] "Date")
 (defmethod -parse-ast-node [:type :any] [_ _] "any")
 (defmethod -parse-ast-node [:type :undefined] [_ _] "undefined")
 (defmethod -parse-ast-node :const [{:keys [const]} options]

--- a/src/malli_ts/core.cljc
+++ b/src/malli_ts/core.cljc
@@ -24,10 +24,23 @@
                   p2 (get-path f2)]
               (str "./"  (.relativize p1 p2))))))
 
+(defn- -schema-properties
+  [?schema options]
+  (if ?schema
+    (-> (if (= (m/type ?schema options) ::m/val)
+          (-> ?schema (m/children options) first)
+          ?schema)
+        (m/properties options))
+    nil))
+
 (defn- -dispatch-parse-ast-node
   [node options]
   (cond
-    (some-> node :schema (m/properties options) ::external-type) :external-type
+    (if-let [{:keys [schema]} node]
+      (-> schema (-schema-properties options) ::external-type)
+      nil)
+    :external-type
+
     (not (some? node)) :nil-node
     (:$ref node) :$ref
     (:type node) [:type (:type node)]
@@ -141,10 +154,14 @@
                                                    file
                                                    files-import-alias*
                                                    file-imports*
-                                                   schema-id->type-options]}]
-  (let [{:keys [::t-name ::t-path ::t-alias]} (m/properties schema)
-        {:keys [t-name t-path t-alias]
-         :or {t-name t-name t-path t-path t-alias t-alias}} (get schema-id->type-options deref-type)
+                                                   schema-id->type-options]
+                                            :as options}]
+  (let [{:keys [::external-type ::t-path ::t-alias]} (-schema-properties schema options)
+
+        {:keys [external-type t-path t-alias]
+         :or {external-type external-type t-path t-path t-alias t-alias}}
+        (get schema-id->type-options deref-type)
+
         t-path-str (or (:absolute t-path) t-path)
         is-imported-already (if t-path-str (@file-imports* t-path) nil)
         canonical-alias (if t-path-str (get @files-import-alias* t-path-str) nil)
@@ -161,7 +178,7 @@
       (swap! file-imports* update file set/union #{t-path}))
     (when (and import-alias (not canonical-alias))
       (swap! files-import-alias* assoc t-path-str import-alias))
-    (str (if import-alias (str import-alias ".") nil) t-name)))
+    (str (if import-alias (str import-alias ".") nil) external-type)))
 
 (defn- letter-args
   ([letter-arg]
@@ -305,7 +322,7 @@
               (-parse-ast-node
                (->ast schema-id options)
                (merge options
-                      {:deref-type schema-id 
+                      {:deref-type schema-id
                        :file file
                        :t-options type-options}))
               jsdoc-literal
@@ -443,15 +460,13 @@
    (parse-ns-schemas ns-coll {})))
 
 (defn external-type
-  ([type-name type-path type-import-alias]
-   [any? {::external-type true
-          ::t-name type-name
-          ::t-path (cond
-                     (nil? type-path) nil
-                     (map? type-path) type-path
-                     :else {:absolute type-path})
-          ::t-alias type-import-alias}])
-  ([type-name type-path]
-   (external-type type-name type-path nil))
-  ([type-name]
-   (external-type type-name nil nil)))
+  [external-type-name & {:keys [import-path import-alias type-name schema]}]
+  (letfn [(?assoc [m k v] (if v (assoc m k v) m))]
+    [(or schema any?)
+     (-> (?assoc {} ::external-type external-type-name)
+         (?assoc ::t-name type-name)
+         (?assoc ::t-path (cond
+                            (nil? import-path) nil
+                            (map? import-path) import-path
+                            :else {:absolute import-path}))
+         (?assoc ::t-alias import-alias))]))

--- a/test/malli_ts/core_test.cljc
+++ b/test/malli_ts/core_test.cljc
@@ -10,7 +10,7 @@
 
 (comment
   (mi/instrument! 
-   {:filters [(mi/-filter-ns 'malli-ts.core)] 
+   {:filters [(mi/-filter-ns 'malli-ts.core)]
     :report (malli-dev-pretty/thrower)})
   
   (mi/unstrument!))
@@ -73,15 +73,15 @@
     :random.dir.universe/import-test-fn :random.util.string/get-default-string-decoder
 
     :random.util.string/get-default-string-decoder
-    [:=> :catn (mts/external-type "StringDecoder" "string_decoder")]
+    [:=> :catn (mts/external-type "StringDecoder" :import-path "string_decoder" :schema some?)]
     
     ::answerUltimateQuestion [:=> :cat :random.dir.universe/answer-to-everything]
 
-    :global/date (mts/external-type "Date")
+    :global/date (mts/external-type "Date" :schema inst?)
     ::now [:=> [:cat] :global/date]
 
     ;; explicit "absolute" path (already default )
-    :crypto/hash (mts/external-type "Hash" {:absolute "crypto"} "crypto")
+    :crypto/hash (mts/external-type "Hash" :import-path {:absolute "crypto"} :import-alias "crypto")
     ::toSha256 [:=> [:catn [:s string?]] :crypto/hash]}})
 
 (comment
@@ -89,18 +89,27 @@
   (parse-ns-schemas parse-ns-schemas-data parse-files-options))
 
 (deftest parsing
+  (is (= {"user.d.ts" "type event = {\"value\":any,\"timestamp\":Date};"}
+         (mts/parse-ns-schemas
+          #{'user}
+          {:registry
+           {:date [inst? {::mts/external-type "Date"}]
+            :user/event [:map
+                         [:value any?]
+                         [:timestamp :date]]}})))
+
   (is (= {"malli_ts.ts.d.ts"
           "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random/dir/universe.d.ts';\n\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var k: (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var sym: (s:string) => any;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport var to_clj: (o:any) => any;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport var validate: (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport var answer_ultimate_question: () => random_dir_universe.answerToEverything;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport var now: () => Date;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport var toSha256: (s:string) => crypto.Hash;",
           "random/dir/universe.d.ts"
           "import * as utilString from './../util/string';\n\n/**\n * @schema [:enum 42]\n */\nexport type answerToEverything = (42);\n/**\n * @schema :random.util.string/get-default-string-decoder\n */\nexport type import_test_fn = utilString.get_default_string_decoder;",
           "random/util/string.d.ts"
-          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [any? #:malli-ts.core{:external-type true, :t-name \"StringDecoder\", :t-path {:absolute \"string_decoder\"}, :t-alias nil}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;"}
+          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [some? #:malli-ts.core{:external-type \"StringDecoder\", :t-path {:absolute \"string_decoder\"}}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;"}
          (parse-files parse-files-data parse-files-options)))
 
   (is (= {"random.dir.universe.d.ts"
           "import * as utilString from './random.util.string';\n\n/**\n * @schema [:enum 42]\n */\nexport type answer_to_everything = (42);\n/**\n * @schema :random.util.string/get-default-string-decoder\n */\nexport type import_test_fn = utilString.get_default_string_decoder;",
           "random.util.string.d.ts"
-          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [any? #:malli-ts.core{:external-type true, :t-name \"StringDecoder\", :t-path {:absolute \"string_decoder\"}, :t-alias nil}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;",
+          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [some? #:malli-ts.core{:external-type \"StringDecoder\", :t-path {:absolute \"string_decoder\"}}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;",
           "malli_ts.core_test.d.ts"
           "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random.dir.universe';\n\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport type answer_ultimate_question = () => random_dir_universe.answer_to_everything;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport type validate = (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport type now = () => Date;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport type to_clj = (o:any) => any;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport type to_sha_256 = (s:string) => crypto.Hash;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport type sym = (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport type k = (s:string) => any;"}
          (parse-ns-schemas parse-ns-schemas-data parse-files-options))))
@@ -109,5 +118,7 @@
   (testing "ast parsing"
     (function-types))
   (testing "declaration"
-    (declaration)))
+    (declaration))
+  (testing "parsing"
+    (parsing)))
 

--- a/test/malli_ts/core_test.cljc
+++ b/test/malli_ts/core_test.cljc
@@ -89,6 +89,13 @@
   (parse-ns-schemas parse-ns-schemas-data parse-files-options))
 
 (deftest parsing
+  (is (= {"user.d.ts" "type event = {\"value\":any,\"timestamp\":Date};"}
+         (parse-ns-schemas
+          #{'user}
+          {:registry {:user/event [:map
+                                   [:value any?]
+                                   [:timestamp inst?]]}})))
+
   (is (= {"malli_ts.ts.d.ts"
           "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random/dir/universe.d.ts';\n\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var k: (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var sym: (s:string) => any;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport var to_clj: (o:any) => any;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport var validate: (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport var answer_ultimate_question: () => random_dir_universe.answerToEverything;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport var now: () => Date;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport var toSha256: (s:string) => crypto.Hash;",
           "random/dir/universe.d.ts"

--- a/test/malli_ts/core_test.cljc
+++ b/test/malli_ts/core_test.cljc
@@ -9,10 +9,10 @@
    [malli.dev.pretty :as malli-dev-pretty]))
 
 (comment
-  (mi/instrument! 
-   {:filters [(mi/-filter-ns 'malli-ts.core)] 
+  (mi/instrument!
+   {:filters [(mi/-filter-ns 'malli-ts.core)]
     :report (malli-dev-pretty/thrower)})
-  
+
   (mi/unstrument!))
 
 
@@ -68,20 +68,20 @@
     ::sym [:=> [:catn [:s string?]] any?]
     ::toClj [:=> [:catn [:o any?]] any?]
     ::validate [:=> [:catn [:schema any?] [:val any?]] any?]
-    
+
     :random.dir.universe/answer-to-everything [:enum 42]
     :random.dir.universe/import-test-fn :random.util.string/get-default-string-decoder
 
     :random.util.string/get-default-string-decoder
-    [:=> :catn (mts/external-type "StringDecoder" "string_decoder")]
-    
+    [:=> :catn (mts/external-type "StringDecoder" :import-path "string_decoder" :schema some?)]
+
     ::answerUltimateQuestion [:=> :cat :random.dir.universe/answer-to-everything]
 
-    :global/date (mts/external-type "Date")
+    :global/date (mts/external-type "Date" :schema inst?)
     ::now [:=> [:cat] :global/date]
 
     ;; explicit "absolute" path (already default )
-    :crypto/hash (mts/external-type "Hash" {:absolute "crypto"} "crypto")
+    :crypto/hash (mts/external-type "Hash" :import-path {:absolute "crypto"} :import-alias "crypto")
     ::toSha256 [:=> [:catn [:s string?]] :crypto/hash]}})
 
 (comment
@@ -94,20 +94,27 @@
           #{'user}
           {:registry {:user/event [:map
                                    [:value any?]
-                                   [:timestamp inst?]]}})))
+                                   [:timestamp inst?]]}})
+         (parse-ns-schemas
+          #{'user}
+          {:registry
+           {:date [inst? {::mts/external-type "Date"}]
+            :user/event [:map
+                         [:value any?]
+                         [:timestamp :date]]}})))
 
   (is (= {"malli_ts.ts.d.ts"
           "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random/dir/universe.d.ts';\n\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var k: (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport var sym: (s:string) => any;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport var to_clj: (o:any) => any;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport var validate: (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport var answer_ultimate_question: () => random_dir_universe.answerToEverything;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport var now: () => Date;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport var toSha256: (s:string) => crypto.Hash;",
           "random/dir/universe.d.ts"
           "import * as utilString from './../util/string';\n\n/**\n * @schema [:enum 42]\n */\nexport type answerToEverything = (42);\n/**\n * @schema :random.util.string/get-default-string-decoder\n */\nexport type import_test_fn = utilString.get_default_string_decoder;",
           "random/util/string.d.ts"
-          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [any? #:malli-ts.core{:external-type true, :t-name \"StringDecoder\", :t-path {:absolute \"string_decoder\"}, :t-alias nil}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;"}
+          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [some? #:malli-ts.core{:external-type \"StringDecoder\", :t-path {:absolute \"string_decoder\"}}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;"}
          (parse-files parse-files-data parse-files-options)))
 
   (is (= {"random.dir.universe.d.ts"
           "import * as utilString from './random.util.string';\n\n/**\n * @schema [:enum 42]\n */\nexport type answer_to_everything = (42);\n/**\n * @schema :random.util.string/get-default-string-decoder\n */\nexport type import_test_fn = utilString.get_default_string_decoder;",
           "random.util.string.d.ts"
-          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [any? #:malli-ts.core{:external-type true, :t-name \"StringDecoder\", :t-path {:absolute \"string_decoder\"}, :t-alias nil}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;",
+          "import * as string_decoder from 'string_decoder';\n\n/**\n * @schema [:=> :catn [some? #:malli-ts.core{:external-type \"StringDecoder\", :t-path {:absolute \"string_decoder\"}}]]\n */\nexport type get_default_string_decoder = () => string_decoder.StringDecoder;",
           "malli_ts.core_test.d.ts"
           "import * as crypto from 'crypto';\nimport * as random_dir_universe from './random.dir.universe';\n\n/**\n * @schema [:=> :cat :random.dir.universe/answer-to-everything]\n */\nexport type answer_ultimate_question = () => random_dir_universe.answer_to_everything;\n/**\n * @schema [:=> [:catn [:schema any?] [:val any?]] any?]\n */\nexport type validate = (schema:any, val:any) => any;\n/**\n * @schema [:=> :cat :global/date]\n */\nexport type now = () => Date;\n/**\n * @schema [:=> [:catn [:o any?]] any?]\n */\nexport type to_clj = (o:any) => any;\n/**\n * @schema [:=> [:catn [:s string?]] :crypto/hash]\n */\nexport type to_sha_256 = (s:string) => crypto.Hash;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport type sym = (s:string) => any;\n/**\n * @schema [:=> [:catn [:s string?]] any?]\n */\nexport type k = (s:string) => any;"}
          (parse-ns-schemas parse-ns-schemas-data parse-files-options))))
@@ -116,5 +123,7 @@
   (testing "ast parsing"
     (function-types))
   (testing "declaration"
-    (declaration)))
+    (declaration))
+  (testing "parsing"
+    (parsing)))
 


### PR DESCRIPTION
The right way of using external types:

```clojure
(register! ::inst [inst? {::mts/external-type "Date" ::mts/t-name "Inst"}])
```

This will give you

```ts
type Inst = Date
```

There are changes in `mts/external-type` function signature:
```clojure
(defn external-type
  [external-type-name & {:keys [import-path import-alias type-name schema]}] ,,,)
```

Plus minor fix that was documented as a new test