### PR TITLE
Implement `js/Proxy` enumeration and match `.d.ts` files

### DIFF
--- a/src/malli_ts/ast.cljc
+++ b/src/malli_ts/ast.cljc
@@ -1,5 +1,7 @@
 (ns malli-ts.ast
-  (:require [malli.core :as m]))
+  (:require [camel-snake-kebab.core :as csk]
+            [malli.core :as m]
+            [malli-ts.core :as-alias mts]))
 
 (defprotocol TsSchema
   (-parse-schema-node [this children options]
@@ -84,12 +86,20 @@
 
 (defmethod parse-schema-node ::m/val [_ _ children _] (first children))
 
-(defmethod parse-schema-node :map [_ _ children _]
+(defmethod parse-schema-node :map [_ _ children {:keys [default-to-camel-case] :as options}]
   (let [get-optional (fn [m] (or (get m :optional) (get m "optional")))
         optional-xf (comp (filter (m/-comp get-optional second)) (map first))
         optional (into #{} optional-xf children)
         object {:type :object
-                :properties (apply array-map (mapcat (fn [[k _ s]] [k s]) children))}]
+                :properties (->> children
+                                 (mapcat
+                                  (fn [[k opts s]]
+                                    (let [k' (or (-> opts ::mts/clj<->js :prop (keyword))
+                                                 (if default-to-camel-case
+                                                   (csk/->camelCase (name k))
+                                                   (name k)))]
+                                      [k' s])))
+                                 (apply array-map))}]
     (if (empty? optional)
       object
       (assoc object :optional optional))))

--- a/src/malli_ts/core.cljc
+++ b/src/malli_ts/core.cljc
@@ -119,8 +119,7 @@
 (defmethod -parse-ast-node [:type :object] [{:keys [properties
                                                     optional
                                                     index-signature]}
-                                            {:keys [default-to-camel-case]
-                                             :as options}]
+                                            options]
   (let [idx-sign-literal (if index-signature
                            (str "[k:" (-parse-ast-node (first index-signature) options) "]:"
                                 (-parse-ast-node (second index-signature) options))
@@ -129,9 +128,7 @@
                              (string/join
                               ","
                               (map (fn [[k v]]
-                                     (let [property-name (if default-to-camel-case
-                                                           (csk/->camelCase (name k))
-                                                           (name k))]
+                                     (let [property-name (name k)]
                                        (str \" property-name \"
                                             (if (contains? optional k) "?" nil) ":"
                                             (-parse-ast-node v options))))

--- a/src/malli_ts/core.cljc
+++ b/src/malli_ts/core.cljc
@@ -117,7 +117,6 @@
   (str "(" (string/join "&" (map #(-parse-ast-node % options) items)) ")"))
 
 (defmethod -parse-ast-node [:type :object] [{:keys [properties
-                                                    optional
                                                     index-signature]}
                                             options]
   (let [idx-sign-literal (if index-signature
@@ -127,10 +126,10 @@
         properties-literal (if-not (empty? properties)
                              (string/join
                               ","
-                              (map (fn [[k v]]
+                              (map (fn [[k [v opts]]]
                                      (let [property-name (name k)]
                                        (str \" property-name \"
-                                            (if (contains? optional k) "?" nil) ":"
+                                            (if (:optional opts) "?" nil) ":"
                                             (-parse-ast-node v options))))
                                    properties))
                              nil)]

--- a/src/malli_ts/data_mapping.cljs
+++ b/src/malli_ts/data_mapping.cljs
@@ -59,18 +59,18 @@
           :map-of
           , (second children)
 
+          :map
+          , (->> children
+                 (reduce
+                  (fn [x [k opts s]]
+                    (let [p (-> opts ::mts/clj<->js :prop (or (csk/->camelCaseString k)))
+                          m (Mapping. k p (first s))]
+                      (assoc! x, k m, p m)))
+                  (transient {}))
+                 (persistent!))
+
           ; else
           (cond
-            (= s-type :map)
-            , (->> children
-                   (reduce
-                    (fn [x [k opts s]]
-                      (let [p (-> opts ::mts/clj<->js :prop (or (csk/->camelCaseString k)))
-                            m (Mapping. k p (first s))]
-                        (assoc! x, k m, p m)))
-                    (transient {}))
-                   (persistent!))
-
             (empty? path)
             , (first children)
 

--- a/src/malli_ts/data_mapping.cljs
+++ b/src/malli_ts/data_mapping.cljs
@@ -50,6 +50,9 @@
                   {::ref ref})
                 result))
 
+          (:set :sequential :vector)
+          , (first children)
+          
           (:enum :or)
           , (m/form schema')
 

--- a/src/malli_ts/data_mapping.cljs
+++ b/src/malli_ts/data_mapping.cljs
@@ -53,13 +53,15 @@
           (:enum :or)
           , (m/form schema')
 
+          :schema
+          , (first children)
+          
+          :map-of
+          , (second children)
+
           ; else
           (cond
-            (empty? path)
-            , (first children)
-
-            (and (= s-type :map)
-                 (seq children))
+            (= s-type :map)
             , (->> children
                    (reduce
                     (fn [x [k opts s]]
@@ -69,9 +71,8 @@
                     (transient {}))
                    (persistent!))
 
-            (and (= s-type ::m/schema)
-                 (sequential? (first children)))
-            , (ffirst children)
+            (empty? path)
+            , (first children)
 
             (primitive? s-type)
             , s-type

--- a/src/malli_ts/data_mapping.cljs
+++ b/src/malli_ts/data_mapping.cljs
@@ -50,15 +50,12 @@
                   {::ref ref})
                 result))
 
-          (:set :sequential :vector)
+          (:schema :set :sequential :vector)
           , (first children)
-          
+
           (:enum :or)
           , (m/form schema')
 
-          :schema
-          , (first children)
-          
           :map-of
           , (second children)
 

--- a/src/malli_ts/data_mapping/to_clj.cljs
+++ b/src/malli_ts/data_mapping/to_clj.cljs
@@ -40,8 +40,12 @@
    (if-some [v (unwrap v)] v 
    ;else
      (if-some [bean' (cond (object? v) true (array? v) false)]
-       (let [bean-context
-             (BeanContext. js<->clj-mapping (::mts-dm/root js<->clj-mapping) nil)]
+       (let [root
+             (::mts-dm/root js<->clj-mapping)
+             root
+             (if-let [ref (::mts-dm/ref root)] (js<->clj-mapping ref) #_else root)
+             bean-context
+             (BeanContext. js<->clj-mapping root nil)]
          (if bean'
            (b/Bean. nil v bean-context true nil nil nil)
            (b/ArrayVector. nil bean-context v nil)))

--- a/src/malli_ts/data_mapping/to_clj.cljs
+++ b/src/malli_ts/data_mapping/to_clj.cljs
@@ -13,8 +13,10 @@
 (deftype BeanContext [js<->clj-mapping mapping ^:mutable sub-cache]
   b/BeanContext
   (keywords? [_] true)
-  (key->prop [_ key'] (let [s (mapping key')] (set! sub-cache s) (if s (.-prop s) (name key'))))
-  (prop->key [_ prop] (let [s (mapping prop)] (set! sub-cache s) (if s (.-key s) (keyword prop))))
+  (key->prop [_ key']
+    (let [s (get mapping key')] (set! sub-cache s) (if s (.-prop s) (name key'))))
+  (prop->key [_ prop]
+    (let [s (get mapping prop)] (set! sub-cache s) (if s (.-key s) (keyword prop))))
   (transform [_ v prop key' nth']
     (if-some [v (unwrap v)] v
     ;else

--- a/src/malli_ts/data_mapping/to_clj.cljs
+++ b/src/malli_ts/data_mapping/to_clj.cljs
@@ -6,8 +6,9 @@
    [cljs-bean.core :as b :refer [bean?]]))
 
 (defn unwrap [v]
-  (or (unchecked-get v "unwrap/clj")
-      (when (bean? v) v)))
+  (when v
+    (or (unchecked-get v "unwrap/clj")
+        (when (bean? v) v))))
 
 (deftype BeanContext [js<->clj-mapping mapping ^:mutable sub-cache]
   b/BeanContext

--- a/src/malli_ts/data_mapping/to_clj.cljs
+++ b/src/malli_ts/data_mapping/to_clj.cljs
@@ -46,10 +46,10 @@
      ;else
        v)))
 
-  ([x registry schema]
+  ([x registry schema & [mapping-options]]
    (let [s (m/schema [:schema {:registry registry}
                       schema])]
-     (to-clj x (mts-dm/clj<->js-mapping s)))))
+     (to-clj x (mts-dm/clj<->js-mapping s mapping-options)))))
 
 (comment
 

--- a/src/malli_ts/data_mapping/to_clj.cljs
+++ b/src/malli_ts/data_mapping/to_clj.cljs
@@ -13,8 +13,8 @@
 (deftype BeanContext [js<->clj-mapping mapping ^:mutable sub-cache]
   b/BeanContext
   (keywords? [_] true)
-  (key->prop [_ key'] (if-let [s (mapping key')] (do (set! sub-cache s) (.-prop s)) (name key')))
-  (prop->key [_ prop] (if-let [s (mapping prop)] (do (set! sub-cache s) (.-key s)) (keyword prop)))
+  (key->prop [_ key'] (let [s (mapping key')] (set! sub-cache s) (if s (.-prop s) (name key'))))
+  (prop->key [_ prop] (let [s (mapping prop)] (set! sub-cache s) (if s (.-key s) (keyword prop))))
   (transform [_ v prop key' nth']
     (if-some [v (unwrap v)] v
     ;else

--- a/src/malli_ts/data_mapping/to_clj.cljs
+++ b/src/malli_ts/data_mapping/to_clj.cljs
@@ -13,14 +13,14 @@
 (deftype BeanContext [js<->clj-mapping mapping ^:mutable sub-cache]
   b/BeanContext
   (keywords? [_] true)
-  (key->prop [_ key'] (let [s (mapping key')] (set! sub-cache s) (.-prop s)))
-  (prop->key [_ prop] (let [s (mapping prop)] (set! sub-cache s) (.-key s)))
+  (key->prop [_ key'] (if-let [s (mapping key')] (do (set! sub-cache s) (.-prop s)) (name key')))
+  (prop->key [_ prop] (if-let [s (mapping prop)] (do (set! sub-cache s) (.-key s)) (keyword prop)))
   (transform [_ v prop key' nth']
     (if-some [v (unwrap v)] v
     ;else
       (if-some [bean' (cond (object? v) true (array? v) false)]
         (let [sub-mapping
-              (if nth'
+              (if (or nth' (not sub-cache))
                 mapping
               ;else
                 (let [s (.-schema sub-cache)]

--- a/src/malli_ts/data_mapping/to_js.cljs
+++ b/src/malli_ts/data_mapping/to_js.cljs
@@ -79,10 +79,10 @@
    (let [cur (::mts-dm/root mapping)
          cur (if-let [ref (::mts-dm/ref cur)] (mapping ref) #_else cur)]
      (to-js' x mapping cur)))
-  ([x registry schema]
+  ([x registry schema & [mapping-options]]
    (let [s (m/schema [:schema {:registry registry}
                       schema])
-         m (mts-dm/clj<->js-mapping s)]
+         m (mts-dm/clj<->js-mapping s mapping-options)]
      (to-js x m))))
 
 (comment

--- a/src/malli_ts/data_mapping/to_js.cljs
+++ b/src/malli_ts/data_mapping/to_js.cljs
@@ -56,6 +56,9 @@
          ^boolean (unchecked-get x "unwrap/clj"))
      , x
 
+     (b/bean? x)
+     , (b/->js x)
+
      (or (sequential? x)
          (set? x))
      , (let [len (count x)

--- a/test/malli_ts/data_mapping_test.cljs
+++ b/test/malli_ts/data_mapping_test.cljs
@@ -47,7 +47,7 @@
     (m/schema [:schema {:registry {::order-items order-items-schema}}
                order-schema])))
 
-(def mapping (sut/clj<->js-mapping schema))
+(def mapping (sut/clj<->js-mapping schema {:default-to-camel-case true}))
 
 (deftest root-reference
   (let [root (m/schema [:schema {:registry {::root schema}} ::root])

--- a/test/malli_ts/data_mapping_test.cljs
+++ b/test/malli_ts/data_mapping_test.cljs
@@ -49,6 +49,18 @@
 
 (def mapping (sut/clj<->js-mapping schema))
 
+(deftest root-reference
+  (let [root (m/schema [:schema {:registry {::root schema}} ::root])
+        clj-map
+        {:model-type   ::order
+         :order/id     "a-root-id-1234"
+         :order/type   "Reference Gear"} 
+        js-obj (sut-tj/to-js clj-map {} root)]
+    (testing "to-js with a one-off mapping to root reference should work"
+      (is (m/validate root clj-map))
+      (is (= "Reference Gear" (:order/type clj-map)))
+      (is (= "Reference Gear" (aget js-obj "orderType"))))))
+
 ;; TODO:
 ;; 1. Add another test for references
 ;; 2. For duplicate property names in different locations in the schema


### PR DESCRIPTION
- Implements `ownKeys` & `getOwnPropertyDescriptor` to support `{ ...spread }` and `toJSON`
- Implement `::clj<->js :prop` in `.d.ts` generation
- Map `:schema` to the actual schema
- Map `:set` `:sequential` `:vector` schemas to their child type
- Don't crash in `to-clj` and `to-js` when a mapping of the given `key` or `prop` cannot be found
- Don't crash on `null` and `undefined` values